### PR TITLE
Add training sample inspection and debugging artifacts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ sentencepiece>=0.1.99
 rouge-score>=0.1.2
 numpy>=1.23
 tensorboard>=2.14.0
+matplotlib>=3.7.0
+bert-score>=0.3.13


### PR DESCRIPTION
## Summary
- add CLI options to control dumping of good/bad training samples and optional output directory
- compute per-sample Lead-3, ROUGE, and BERTScore metrics plus attention heatmaps for best and worst examples, and save/log them for inspection
- record inspection metadata alongside the evaluation report and add dependencies needed for visualization and BERTScore

## Testing
- python -m compileall week3/train_abstractive.py

------
https://chatgpt.com/codex/tasks/task_e_68dbc5e568f0832e87edd9338ea2a387